### PR TITLE
Add trusted proxies configuration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,8 @@
 {
     auto_https off
+    servers {
+		trusted_proxies static 169.254.0.0/16
+	}
 }
 
 :8080


### PR DESCRIPTION
Followed Caddy docs for the configuration on a global level: https://caddyserver.com/docs/caddyfile/options#trusted-proxies
Interestingly, the IP used by Azure load balancer is not from a private range, but still kinda private. This was an interesting read: https://www.auvik.com/franklyit/blog/special-ip-address-ranges/#h2-1